### PR TITLE
Consistent non-interaction, fixing missing openssl/bio.h during kerne…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ LOSETUP_D_IMG(){
 }
 
 install_reqpkg() {
-    apt install make bison bc flex kpartx xz-utils qemu-user-static
+    apt install make bison bc flex kpartx xz-utils qemu-user-static libssl-dev -y
 }
 
 get_riscv_system() {
@@ -50,7 +50,7 @@ get_riscv_system() {
     mkdir ${rootfs_dir}
     tar -zxvf rootfs.tar.gz -C ${rootfs_dir}
     cp -b /etc/resolv.conf ${rootfs_dir}/etc/resolv.conf
-    chroot ${rootfs_dir} dnf update
+    chroot ${rootfs_dir} dnf update -y
     chroot ${rootfs_dir} dnf install alsa-utils haveged wpa_supplicant vim net-tools iproute iputils NetworkManager bluez fedora-release-server -y
     chroot ${rootfs_dir} dnf install wget openssh-server openssh-clients passwd hostname parted linux-firmware-whence chkconfig e2fsprogs -y
     echo fedora-riscv > ${rootfs_dir}/etc/hostname


### PR DESCRIPTION
The last two dnf commands have a "-y" so that the script does not ask for confirmation. I have added this to the dnf update as well as to the apt commands, to make non-interaction more consistent.

I have also added the installation of the package libssl-dev to fix an error about a missing "openssl/bio.h" during kernel compilation.